### PR TITLE
22 allow specifying an array of validation functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `onFormValuesChange` and `onFormValidityChange` props for `Form` have been removed and replaced with `onChange` and `onSubmit`
 - `setFormInputValue`, `setFormInputValidity`, `valid` as props for components wrapped by `withFormHandling` have been removed and replaced with `setValue` and `error`
 
+### Updated
+- allow `withFormHandling`'s optional `onChange` callback prop to be an array of callbacks as well as a single callback function. ([#22](https://github.com/JBKLabs/react-form/issues/22))
+
 ### Removed
 - `TextInput` component which has `react-form` preconfigured
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ more on this below.
 
 **Error Handling**
 
-By default, `react-form` does not provide any error handling. The second argument for the HoC `withFormHandling` or `onChange` is how you can declare validation rules for your components. `onChange(value, props)` will be called automatically by `react-form` everytime the provided `setValue` prop is called. The first arg `value` will be the next value while `props` will be all props passed to your wrapped component. This function when called sets the value of `error` on your behalf. Any error thrown by the `onChange` callback you provide will automatically be caught and passed to your component via the `error` prop.
+By default, `react-form` does not provide any error handling. The second argument for the HoC `withFormHandling` or `onChange` is how you can declare validation rules for your components. `onChange` is expected to be either a single callback or an array of callbacks and will be called automatically by `react-form` everytime the provided `setValue` prop is called. The first arg `value` will be the next value while `props` will be all props passed to your wrapped component. This function when called sets the value of `error` on your behalf. Any error thrown by the `onChange` callback you provide will automatically be caught and passed to your component via the `error` prop.
 
 ```jsx
 export default withFormHandling(Input, (value) => {
@@ -105,6 +105,15 @@ export default withFormHandling(Input, (value, { regex }) => {
     throw new ValidationError('Invalid pattern.')
   }
 });
+```
+
+If you provide an array of callback functions, each will run until an error is thrown.
+
+```jsx
+export default withFormHandling(Input, [
+  () => throw new ValidationError('Invalid'),
+  someValidationFunction // never called because the first callback always errors
+]);
 ```
 
 **Input Names**

--- a/src/withFormHandling.js
+++ b/src/withFormHandling.js
@@ -2,7 +2,7 @@ import React, { useEffect, useContext, useCallback } from 'react';
 
 import FormContext from './FormContext';
 
-const withFormHandling = (FormInput, onFormChange = () => {}) => ({
+const withFormHandling = (FormInput, onFormChange = () => { }) => ({
   name,
   defaultValue = '',
   ...remainingProps
@@ -35,7 +35,11 @@ const withFormHandling = (FormInput, onFormChange = () => {}) => ({
 
   useEffect(() => {
     try {
-      onFormChange(value, remainingProps);
+      if (typeof onFormChange === 'function') {
+        onFormChange(value, remainingProps);
+      } else if (Array.isArray(onFormChange)) {
+        onFormChange.forEach(cb => cb(value, remainingProps));
+      }
       if (error !== null) {
         setError(name, null);
       }


### PR DESCRIPTION
Closes #22 

## Changes

* update README
* allow `withFormHandling` optional `onChange` prop to be an array of functions

## Steps to Test

* [x] try to define an input with an array of validation functions
* [x] confirm the first error is caught rather than the last one (if two always failing functions are provided, the error thrown by the first one should be passed to the input).
