### PR TITLE
Define inputProps and pass to inputs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules
 **/dist
+examples/*
+!examples/native
+!examples/web

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `@jbk/react-form/native` module export for react native development
 - ability to reset inputs back to their default values via `resetInputs`
-- `inputProps` prop for meta values passed into components wrapped by `withFormHandling`
+- `inputProps` prop for meta values passed into components wrapped by `withFormHandling` ([#20](https://github.com/JBKLabs/react-form/issues/20))
 
 ### Changed
 - `onFormValuesChange` and `onFormValidityChange` props for `Form` have been removed and replaced with `onChange` and `onSubmit`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `@jbk/react-form/native` module export for react native development
 - ability to reset inputs back to their default values via `resetInputs`
+- `inputProps` prop for meta values passed into components wrapped by `withFormHandling`
 
 ### Changed
 - `onFormValuesChange` and `onFormValidityChange` props for `Form` have been removed and replaced with `onChange` and `onSubmit`

--- a/README.md
+++ b/README.md
@@ -53,11 +53,12 @@ This HoC will provide `Component` with 3 props:
 `value`: The current value for the input  
 `setValue`: A callback function which replace the existing form value 
 `error`: The current error message associated with the input, or null
+`inputProps`: An object of meta values which are passed to all inputs within the form
 
 ```jsx
-const Input = ({ value, setValue, error }) => (
+const Input = ({ value, setValue, error, inputProps }) => (
   <div className="form-group">
-    {error && <div className="form-error">{error}</div>}
+    {error && inputProps.displayErrors && <div className="form-error">{error}</div>}
     <input
       className="form-input"
       value={value}

--- a/README.md
+++ b/README.md
@@ -203,6 +203,31 @@ This callback function will be called anytime a form value changes.
 
 An example of what this might look like can be seen in the `onSubmit` section.
 
+**inputProps**
+
+This is a simple object that passes user defined props directly to the wrapped inputs. For example:
+
+```jsx
+<Form
+  inputProps={{
+    displayErrors: false,
+  }}
+>
+```
+
+This `inputProps` block would be passed as is automatically to all inputs wrapped by `withFormHandling` making the following possible:
+
+```jsx
+const CustomInput = ({ value, error, setValue, inputProps }) => (
+  <div>
+    { error && inputProps.displayErrors && <div>{error}</div>}
+    <input ... />
+  </div>
+);
+
+export default withFormHandling(CustomInput);
+```
+
 **Resetting Inputs**
 
 In both of the provided `Form` lifecycle hooks, `onChange` and `onSubmit`, you are able to reset the value of one or more inputs back to their default values via the provided `resetInputs(patterns)` function.

--- a/src/formFactory.js
+++ b/src/formFactory.js
@@ -4,7 +4,7 @@ import { transposeKeys, useFormReducer, globMatch } from './util';
 import FormContext from './FormContext';
 
 const formFactory = (FormWrapper) => {
-  const Form = ({ onSubmit, onChange, children, ...remainingProps }) => {
+  const Form = ({ onSubmit, onChange, inputProps, children, ...remainingProps }) => {
     const [form, dispatch] = useFormReducer();
 
     const updateSubscribers = useCallback(
@@ -54,9 +54,10 @@ const formFactory = (FormWrapper) => {
         values: form.values,
         errors: form.errors,
         keys: form.keys,
+        inputProps: form.inputProps,
         ...handlers
       }),
-      [form.errors, form.values, form.keys, handlers]
+      [form.errors, form.values, form.keys, form.inputProps, handlers]
     );
 
     useEffect(() => {

--- a/src/formFactory.js
+++ b/src/formFactory.js
@@ -54,10 +54,10 @@ const formFactory = (FormWrapper) => {
         values: form.values,
         errors: form.errors,
         keys: form.keys,
-        inputProps: form.inputProps,
+        inputProps,
         ...handlers
       }),
-      [form.errors, form.values, form.keys, form.inputProps, handlers]
+      [form.values, form.errors, form.keys, inputProps, handlers]
     );
 
     useEffect(() => {

--- a/src/withFormHandling.js
+++ b/src/withFormHandling.js
@@ -13,6 +13,7 @@ const withFormHandling = (FormInput, onFormChange = () => {}) => ({
     errors,
     setError,
     keys,
+    inputProps,
     setDefault,
     removeKey
   } = useContext(FormContext);
@@ -54,6 +55,7 @@ const withFormHandling = (FormInput, onFormChange = () => {}) => ({
       error={error}
       setValue={setNamedValue}
       name={name}
+      inputProps={inputProps}
       {...remainingProps}
       key={key}
     />

--- a/src/withFormHandling.js
+++ b/src/withFormHandling.js
@@ -47,7 +47,7 @@ const withFormHandling = (FormInput, onFormChange = () => {}) => ({
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [value]);
+  }, [value, inputProps]);
 
   return (
     <FormInput


### PR DESCRIPTION
Closes #20 

## Changes
- Receive `inputProps` to the Form and pass to wrapped inputs

## Steps to Test
- [x] Use this branch of `react-form` in an existing or new project
- [x] Add `inputProps` to Form component
- [x] Print out `inputProps` from Form's wrapped input components